### PR TITLE
CASVALの自動デプロイ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,22 @@ jobs:
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
       - run:
+          name: Add Sops
+          command: |
+            curl -LO https://github.com/mozilla/sops/releases/download/3.3.1/sops-3.3.1.linux
+            chmod +x sops-3.3.1.linux
+            mv sops-3.3.1.linux ./rem/sops
+      - run:
+          name: Deploy casval-rem
+          command: |
+            # Need secret file for application default credential
+            echo $GCLOUD_SERVICE_KEY > secret.json
+            export GOOGLE_APPLICATION_CREDENTIALS=$PWD/secret.json
+
+            cd ./rem/
+            ./sops --decrypt config.enc.env > config.env
+            gcloud -q app deploy
+      - run:
           name: Deploy casval-ui
           command: |
             cp -R ./tmp/ui/dist/ ./ui/dist/
@@ -69,6 +85,14 @@ jobs:
             cp -R ./tmp/admin-ui/dist/ ./admin-ui/dist/
             cd ./admin-ui/
             gcloud -q app deploy
+      - run:
+          name: Deploy Dispatch
+          command: |
+            gcloud -q app deploy dispatch.yaml
+      - run:
+          name: Deploy CronJobs
+          command: |
+            gcloud -q app deploy cron.yaml
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,23 +49,29 @@ jobs:
       - attach_workspace:
           at: ./tmp
       - run:
-          name: Deploy casval-ui
+          name: Auth Google API
+          command: |
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+      - run:
+          name: Deploying the casval-ui files
           working_directory: ui/
           command: |
             cp -R ~/project/tmp/ui/dist/ ~/project/ui/dist/
             gcloud -q app deploy
       - run:
-          name: Deploy casval-admin-ui
+          name: Deploying the casval-admin-ui files
           working_directory: admin-ui/
           command: |
             cp -R ~/project/tmp/admin-ui/dist/ ~/project/admin-ui/dist/
             gcloud -q app deploy
       - run:
-          name: Deploy Dispatch
+          name: Deploying the dispatch file
           command: |
             gcloud -q app deploy dispatch.yaml
       - run:
-          name: Deploy CronJobs
+          name: Deploying the cron jobs
           command: |
             gcloud -q app deploy cron.yaml
 
@@ -79,7 +85,3 @@ workflows:
           requires:
             - build-casval-ui
             - build-casval-admin-ui
-          filters:
-            branches:
-              only:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,73 @@
+version: 2
+jobs:
+  build-casval-ui:
+    docker:
+      - image: circleci/node:10.16.0-stretch
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "./ui/package-lock.json" }}
+          paths:
+            - /caches/ui
+      - run:
+          name: Instsall dependency package
+          command: |
+            cd ui
+            npm ci
+      - run:
+          name: Build casval-ui
+          command: |
+            cd ui
+            npm run build
+      - save_cache:
+          key: npm-cache-{{ checksum "./ui/package-lock.json" }}
+          paths:
+            - ./ui/dist
+      - persist_to_workspace:
+          root: ./ui
+          paths:
+            - dist/
+
+  build-casval-admin-ui:
+    docker:
+      - image: circleci/node:10.16.0-stretch
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "./admin-ui/package-lock.json" }}
+          paths:
+            - /caches/admin-ui
+      - run:
+          name: Instsall dependency package
+          command: |
+            cd admin-ui
+            npm ci
+      - run:
+          name: Build casval-ui
+          command: |
+            cd admin-ui
+            npm run build
+      - save_cache:
+          key: npm-cache-{{ checksum "./admin-ui/package-lock.json" }}
+          paths:
+            - ./admin-ui/dist
+      - persist_to_workspace:
+          root: ./admin-ui
+          paths:
+            - dist/
+#   deploy:
+#     docker:
+#       - image: google/cloud-sdk
+#     steps:
+#       - checkout
+#       - attach_workspace:
+#           at: /caches
+
+workflows:
+  version: 2
+  test-and-build:
+    jobs:
+      - build-casval-ui
+      - build-casval-admin-ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,3 +104,7 @@ workflows:
           requires:
             - build-casval-ui
             - build-casval-admin-ui
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,18 @@ jobs:
       - run: mkdir -p tmp/ui
       - run:
           name: Instsall dependency package
-          command: |
-            cd ui
-            npm ci
+          working_directory: ui/
+          command: npm ci
       - run:
           name: Build casval-ui
+          working_directory: ui/
           command: |
-            cd ui
             npm run build
-            mv dist/ /home/circleci/project/tmp/ui/dist
+            mv dist/ ~/project/tmp/ui/dist
       - persist_to_workspace:
-          root: /home/circleci/project/tmp/
+          root: ~/project/tmp/
           paths:
             - ui/
-
 
   build-casval-admin-ui:
     docker:
@@ -31,17 +29,16 @@ jobs:
       - run: mkdir -p tmp/admin-ui
       - run:
           name: Instsall dependency package
-          command: |
-            cd admin-ui
-            npm ci
+          working_directory: admin-ui/
+          command: npm ci
       - run:
           name: Build casval-ui
+          working_directory: admin-ui/
           command: |
-            cd admin-ui
             npm run build
-            mv dist/ /home/circleci/project/tmp/admin-ui/dist
+            mv dist/ ~/project/tmp/admin-ui/dist
       - persist_to_workspace:
-          root: /home/circleci/project/tmp/
+          root: ~/project/tmp/
           paths:
             - admin-ui/
   deploy:
@@ -65,25 +62,25 @@ jobs:
             mv sops-3.3.1.linux ./rem/sops
       - run:
           name: Deploy casval-rem
+          working_directory: rem/
           command: |
             # Need secret file for application default credential
             echo $GCLOUD_SERVICE_KEY > secret.json
             export GOOGLE_APPLICATION_CREDENTIALS=$PWD/secret.json
 
-            cd ./rem/
             ./sops --decrypt config.enc.env > config.env
             gcloud -q app deploy
       - run:
           name: Deploy casval-ui
+          working_directory: ui/
           command: |
-            cp -R ./tmp/ui/dist/ ./ui/dist/
-            cd ./ui/
+            cp -R ~/project/tmp/ui/dist/ ~/project/ui/dist/
             gcloud -q app deploy
       - run:
           name: Deploy casval-admin-ui
+          working_directory: admin-ui/
           command: |
-            cp -R ./tmp/admin-ui/dist/ ./admin-ui/dist/
-            cd ./admin-ui/
+            cp -R ~/project/tmp/admin-ui/dist/ ~/project/admin-ui/dist/
             gcloud -q app deploy
       - run:
           name: Deploy Dispatch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,3 +85,7 @@ workflows:
           requires:
             - build-casval-ui
             - build-casval-admin-ui
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,28 +49,6 @@ jobs:
       - attach_workspace:
           at: ./tmp
       - run:
-          name: Auth Google API
-          command: |
-            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-      - run:
-          name: Add Sops
-          command: |
-            curl -LO https://github.com/mozilla/sops/releases/download/3.3.1/sops-3.3.1.linux
-            chmod +x sops-3.3.1.linux
-            mv sops-3.3.1.linux ./rem/sops
-      - run:
-          name: Deploy casval-rem
-          working_directory: rem/
-          command: |
-            # Need secret file for application default credential
-            echo $GCLOUD_SERVICE_KEY > secret.json
-            export GOOGLE_APPLICATION_CREDENTIALS=$PWD/secret.json
-
-            ./sops --decrypt config.enc.env > config.env
-            gcloud -q app deploy
-      - run:
           name: Deploy casval-ui
           working_directory: ui/
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,7 @@ jobs:
       - image: circleci/node:10.16.0-stretch
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - npm-cache-{{ checksum "./ui/package-lock.json" }}
-          paths:
-            - /caches/ui
+      - run: mkdir -p tmp/ui
       - run:
           name: Instsall dependency package
           command: |
@@ -20,25 +16,19 @@ jobs:
           command: |
             cd ui
             npm run build
-      - save_cache:
-          key: npm-cache-{{ checksum "./ui/package-lock.json" }}
-          paths:
-            - ./ui/dist
+            mv dist/ /home/circleci/project/tmp/ui/dist
       - persist_to_workspace:
-          root: ./ui
+          root: /home/circleci/project/tmp/
           paths:
-            - dist/
+            - ui/
+
 
   build-casval-admin-ui:
     docker:
       - image: circleci/node:10.16.0-stretch
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - npm-cache-{{ checksum "./admin-ui/package-lock.json" }}
-          paths:
-            - /caches/admin-ui
+      - run: mkdir -p tmp/admin-ui
       - run:
           name: Instsall dependency package
           command: |
@@ -49,21 +39,36 @@ jobs:
           command: |
             cd admin-ui
             npm run build
-      - save_cache:
-          key: npm-cache-{{ checksum "./admin-ui/package-lock.json" }}
-          paths:
-            - ./admin-ui/dist
+            mv dist/ /home/circleci/project/tmp/admin-ui/dist
       - persist_to_workspace:
-          root: ./admin-ui
+          root: /home/circleci/project/tmp/
           paths:
-            - dist/
-#   deploy:
-#     docker:
-#       - image: google/cloud-sdk
-#     steps:
-#       - checkout
-#       - attach_workspace:
-#           at: /caches
+            - admin-ui/
+  deploy:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./tmp
+      - run:
+          name: Auth Google API
+          command: |
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+      - run:
+          name: Deploy casval-ui
+          command: |
+            cp -R ./tmp/ui/dist/ ./ui/dist/
+            cd ./ui/
+            gcloud -q app deploy
+      - run:
+          name: Deploy casval-admin-ui
+          command: |
+            cp -R ./tmp/admin-ui/dist/ ./admin-ui/dist/
+            cd ./admin-ui/
+            gcloud -q app deploy
 
 workflows:
   version: 2
@@ -71,3 +76,7 @@ workflows:
     jobs:
       - build-casval-ui
       - build-casval-admin-ui
+      - deploy:
+          requires:
+            - build-casval-ui
+            - build-casval-admin-ui


### PR DESCRIPTION
対応 issue: 
https://github.com/recruit-tech/casval-admin-ui/issues/2
https://github.com/recruit-tech/casval-ui/issues/5

---

CircleCIを用いてCASVALのmasterが更新された時にgcloudコマンドを用いて自動でデプロイするように対応

成功したCircleCI
https://circleci.com/gh/recruit-tech/casval/68

- [x] sopsの対応
- [x] casval-uiの自動デプロイ
- [x] casval-adminの自動デプロイ
- [x] cron-jobの更新
- [x] dispatchの更新

---

自動デプロイをするにあたり、CircleCI用のServiceAccountを作成した。
付与した権限は以下のとおり。
```
App Engine 管理者
App Engine デプロイ担当者
Cloud Build 編集者
クラウド KMS 暗号鍵の復号化
Cloud Scheduler 管理者 
ストレージのオブジェクト管理者
```
